### PR TITLE
use more conventional names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for band_ind, band in enumerate(data):
         # do something with obs here
         # obs.image is the image
         # obs.weight is the weight map
-        # obs.psf(x, y) will produce an image of the PSF
+        # obs.get_psf(x, y) will produce an image of the PSF
         # obs.wcs is the galsim WCS object associated with the image
         pass
 ```

--- a/descwl_shear_testing/se_obs.py
+++ b/descwl_shear_testing/se_obs.py
@@ -47,7 +47,7 @@ class SEObs(object):
 
     Methods
     -------
-    psf(x, y)
+    get_psf(x, y)
         Draw the PSF at the given image location.
     """
     def __init__(
@@ -134,7 +134,7 @@ class SEObs(object):
             raise ValueError("The \"or\" mask must be a `galsim.Image` or subclass!")
         self._ormask = ormask
 
-    def psf(self, x, y):
+    def get_psf(self, x, y):
         """Draw the PSF at the given image location.
 
         Parameters

--- a/descwl_shear_testing/simple_sim.py
+++ b/descwl_shear_testing/simple_sim.py
@@ -200,7 +200,7 @@ class Sim(object):
             psf_funcs_galsim, psf_funcs_rendered = self._get_psf_funcs_for_band(band)
 
             band_data[band] = []
-            for epoch, wcs, psf_galsim, psf_rendered in zip(
+            for epoch, wcs, psf_galsim, psf_func in zip(
                     range(self.epochs_per_band), wcs_objects,
                     psf_funcs_galsim, psf_funcs_rendered):
 
@@ -227,7 +227,7 @@ class Sim(object):
                         image=se_image,
                         weight=se_weight,
                         wcs=wcs,
-                        psf_function=psf_rendered,
+                        psf_function=psf_func,
                     )
                 )
 
@@ -322,12 +322,12 @@ class Sim(object):
 
     def _get_psf_funcs_for_band(self, band):
         psf_funcs_galsim = []
-        psf_funcs_rendered = []
+        psf_funcs = []
         for epoch in range(self.epochs_per_band):
             pgf, prf = self._get_psf_funcs_for_band_epoch(band, epoch)
             psf_funcs_galsim.append(pgf)
-            psf_funcs_rendered.append(prf)
-        return psf_funcs_galsim, psf_funcs_rendered
+            psf_funcs.append(prf)
+        return psf_funcs_galsim, psf_funcs
 
     def _get_psf_funcs_for_band_epoch(self, band, epoch):
         # using closures here to capture some local state

--- a/descwl_shear_testing/tests/test_se_obs.py
+++ b/descwl_shear_testing/tests/test_se_obs.py
@@ -32,7 +32,7 @@ def test_se_obs_smoke(se_data):
     assert np.array_equal(obs.noise.array, np.ones(DIMS) * 3)
     assert np.array_equal(obs.bmask.array, np.ones(DIMS) * 4)
     assert np.array_equal(obs.ormask.array, np.ones(DIMS) * 5)
-    assert np.array_equal(obs.psf(1, 0).array, np.ones(DIMS) * 6)
+    assert np.array_equal(obs.get_psf(1, 0).array, np.ones(DIMS) * 6)
     assert obs.wcs == galsim.PixelScale(0.2)
 
 
@@ -57,7 +57,7 @@ def test_se_obs_set(attr, val, se_data):
     assert attr == 'noise' or np.array_equal(obs.noise.array, np.ones(DIMS) * 3)
     assert attr == 'bmask' or np.array_equal(obs.bmask.array, np.ones(DIMS) * 4)
     assert attr == 'ormask' or np.array_equal(obs.ormask.array, np.ones(DIMS) * 5)
-    assert np.array_equal(obs.psf(1, 0).array, np.ones(DIMS) * 6)
+    assert np.array_equal(obs.get_psf(1, 0).array, np.ones(DIMS) * 6)
     assert attr == 'wcs' or obs.wcs == galsim.PixelScale(0.2)
 
 
@@ -75,7 +75,7 @@ def test_se_obs_psf_call():
         psf_function=psf_function,
     )
 
-    assert obs.psf(10, 5) == 11
+    assert obs.get_psf(10, 5) == 11
 
 
 @pytest.mark.parametrize('attr', ['image', 'weight', 'noise', 'bmask', 'ormask'])

--- a/descwl_shear_testing/tests/test_simple_sim.py
+++ b/descwl_shear_testing/tests/test_simple_sim.py
@@ -29,4 +29,4 @@ def test_simple_sim_psf_smoke():
         assert len(data[band]) == sim.epochs_per_band
         for epoch in range(sim.epochs_per_band):
             # make sure this call works
-            data[band][epoch].psf(10, 3)
+            data[band][epoch].get_psf(10, 3)


### PR DESCRIPTION
psf(x, y) method renamed to get_psf
psf_rendered renamed to psf_func